### PR TITLE
Bugfix/teacher activity validation

### DIFF
--- a/src/schooling/validators/form_validators.py
+++ b/src/schooling/validators/form_validators.py
@@ -111,9 +111,3 @@ def validate_teacher_last_login(teacher):
     if not hasattr(teacher, 'last_login_date'):
         raise ValidationError(
             'У преподавателя отсутствует информация о последнем посещении.')
-    if teacher.last_login_date + timedelta(days=60) < timezone.now().date():
-        raise ValidationError(
-            f'Преподаватель не проводил занятия '
-            f'в течение последних двух месяцев.\n'
-            f'Последнее посещение: {teacher.last_login_date}.',
-        )


### PR DESCRIPTION
Из функции валидации учителя на его посещаемость убрана проверка, которая не позволяла создать урок для учителя, если он не проводил уроки более 60 дней. При этом оставил основную часть валидации, чтобы сохранилась информации о последнем посещении учителя.