### PR TITLE
delete name in UniqueConstraint in Lesson model

### DIFF
--- a/src/schooling/models.py
+++ b/src/schooling/models.py
@@ -279,7 +279,6 @@ class Lesson(models.Model):
         constraints = [
             models.UniqueConstraint(
                 fields=[
-                    'name',
                     'subject',
                     'teacher_id',
                     'student_id',


### PR DESCRIPTION
Удалено поле name из UniqueConstraint модели Lesson. При создании пула занятий создавались занятия с одинаковыми названиями и при редактировании вылетала ошибка на уникальность названия занятия.